### PR TITLE
RISK-162. Changed Gem Spec Version

### DIFF
--- a/chef-handler-updated-resources.gemspec
+++ b/chef-handler-updated-resources.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'chef-handler-updated-resources'
-  s.version = '0.3.0'
+  s.version = '1.0.0'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Chef report handler to display resources updated in the Chef Run'
   s.description = s.summary


### PR DESCRIPTION
[RISK-162]
Updated Gem Spec Version to 1.0 due to misalignment of creator's versioning in RubyGems

[RISK-162]: https://greenfly.atlassian.net/browse/RISK-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ